### PR TITLE
1.5.1

### DIFF
--- a/ToolbarManager/Config.cs
+++ b/ToolbarManager/Config.cs
@@ -9,12 +9,18 @@ namespace ToolbarManager
 {
     public class PluginConfig
     {
+        // Building from cockpit (Ctrl-G) uses the character profiles
+        public bool UseCharacterProfilesForBuildCockpit = true;
+
+        // Keep the search text between subsequent uses of the Profile dialog
         public bool KeepProfileSearchText = false;
         public string LatestProfileSearchText = "";
 
+        // Keep the search text between subsequent uses of the block search
         public bool KeepBlockSearchText = false;
         public string LatestBlockSearchText = "";
 
+        // Key to start block search
         public MyKeys BlockSearchKey = MyKeys.OemPipe;
     }
 

--- a/ToolbarManager/Gui/PluginConfigDialog.cs
+++ b/ToolbarManager/Gui/PluginConfigDialog.cs
@@ -19,11 +19,14 @@ namespace ToolbarManager.Gui
 
         private MyLayoutTable layoutTable;
 
-        private MyGuiControlLabel keepBlockSearchTextLabel;
-        private MyGuiControlCheckbox keepBlockSearchTextCheckbox;
+        private MyGuiControlLabel mapBuildCockpitToCharacterLabel;
+        private MyGuiControlCheckbox mapBuildCockpitToCharacterCheckbox;
 
         private MyGuiControlLabel keepProfileSearchTextLabel;
         private MyGuiControlCheckbox keepProfileSearchTextCheckbox;
+
+        private MyGuiControlLabel keepBlockSearchTextLabel;
+        private MyGuiControlCheckbox keepBlockSearchTextCheckbox;
 
         private MyControl blockSearchKeyControl;
         private MyGuiControlLabel blockSearchKeyLabel;
@@ -31,7 +34,7 @@ namespace ToolbarManager.Gui
 
         private MyGuiControlButton closeButton;
 
-        public PluginConfigDialog() : base(new Vector2(0.5f, 0.5f), MyGuiConstants.SCREEN_BACKGROUND_COLOR, new Vector2(0.5f, 0.5f), false, null, MySandboxGame.Config.UIBkOpacity, MySandboxGame.Config.UIOpacity)
+        public PluginConfigDialog() : base(new Vector2(0.5f, 0.6f), MyGuiConstants.SCREEN_BACKGROUND_COLOR, new Vector2(0.5f, 0.5f), false, null, MySandboxGame.Config.UIBkOpacity, MySandboxGame.Config.UIOpacity)
         {
             EnabledBackgroundFade = true;
             m_closeOnEsc = true;
@@ -58,6 +61,14 @@ namespace ToolbarManager.Gui
         private void CreateControls()
         {
             AddCaption(Caption);
+
+            CreateCheckbox(
+                out mapBuildCockpitToCharacterLabel,
+                out mapBuildCockpitToCharacterCheckbox,
+                Config.Data.UseCharacterProfilesForBuildCockpit,
+                value => { Config.Data.UseCharacterProfilesForBuildCockpit = value; },
+                "Use character profiles for build cockpit",
+                "Building from cockpit (Ctrl-G) uses the character profiles.");
 
             CreateCheckbox(
                 out keepProfileSearchTextLabel,
@@ -182,11 +193,15 @@ namespace ToolbarManager.Gui
 
         private void LayoutControls()
         {
-            layoutTable = new MyLayoutTable(this, new Vector2(-0.2f, -0.25f), new Vector2(0.20f, 0.25f));
+            layoutTable = new MyLayoutTable(this, new Vector2(-0.2f, -0.3f), new Vector2(0.20f, 0.3f));
             layoutTable.SetColumnWidths(500f, 500f);
-            layoutTable.SetRowHeights(150f, 90f, 90f, 90f, 90f, 180f);
+            layoutTable.SetRowHeights(180f, 90f, 90f, 90f, 90f, 90f, 180f);
 
             var row = 1;
+
+            layoutTable.Add(mapBuildCockpitToCharacterLabel, MyAlignH.Left, MyAlignV.Top, row, 0);
+            layoutTable.Add(mapBuildCockpitToCharacterCheckbox, MyAlignH.Left, MyAlignV.Top, row, 1);
+            row++;
 
             layoutTable.Add(keepProfileSearchTextLabel, MyAlignH.Left, MyAlignV.Top, row, 0);
             layoutTable.Add(keepProfileSearchTextCheckbox, MyAlignH.Left, MyAlignV.Top, row, 1);

--- a/ToolbarManager/Gui/PluginConfigDialog.cs
+++ b/ToolbarManager/Gui/PluginConfigDialog.cs
@@ -170,13 +170,13 @@ namespace ToolbarManager.Gui
             labelControl = new MyGuiControlLabel
             {
                 Text = label,
-                OriginAlign = MyGuiDrawAlignEnum.HORISONTAL_CENTER_AND_VERTICAL_TOP,
+                OriginAlign = MyGuiDrawAlignEnum.HORISONTAL_CENTER_AND_VERTICAL_CENTER,
                 Enabled = enabled,
             };
 
             checkboxControl = new MyGuiControlCheckbox(toolTip: tooltip)
             {
-                OriginAlign = MyGuiDrawAlignEnum.HORISONTAL_CENTER_AND_VERTICAL_TOP,
+                OriginAlign = MyGuiDrawAlignEnum.HORISONTAL_CENTER_AND_VERTICAL_CENTER,
                 IsChecked = value,
                 Enabled = enabled,
                 CanHaveFocus = enabled
@@ -199,20 +199,20 @@ namespace ToolbarManager.Gui
 
             var row = 1;
 
-            layoutTable.Add(mapBuildCockpitToCharacterLabel, MyAlignH.Left, MyAlignV.Top, row, 0);
-            layoutTable.Add(mapBuildCockpitToCharacterCheckbox, MyAlignH.Left, MyAlignV.Top, row, 1);
+            layoutTable.Add(mapBuildCockpitToCharacterLabel, MyAlignH.Left, MyAlignV.Center, row, 0);
+            layoutTable.Add(mapBuildCockpitToCharacterCheckbox, MyAlignH.Left, MyAlignV.Center, row, 1);
             row++;
 
-            layoutTable.Add(keepProfileSearchTextLabel, MyAlignH.Left, MyAlignV.Top, row, 0);
-            layoutTable.Add(keepProfileSearchTextCheckbox, MyAlignH.Left, MyAlignV.Top, row, 1);
+            layoutTable.Add(keepProfileSearchTextLabel, MyAlignH.Left, MyAlignV.Center, row, 0);
+            layoutTable.Add(keepProfileSearchTextCheckbox, MyAlignH.Left, MyAlignV.Center, row, 1);
             row++;
 
-            layoutTable.Add(keepBlockSearchTextLabel, MyAlignH.Left, MyAlignV.Top, row, 0);
-            layoutTable.Add(keepBlockSearchTextCheckbox, MyAlignH.Left, MyAlignV.Top, row, 1);
+            layoutTable.Add(keepBlockSearchTextLabel, MyAlignH.Left, MyAlignV.Center, row, 0);
+            layoutTable.Add(keepBlockSearchTextCheckbox, MyAlignH.Left, MyAlignV.Center, row, 1);
             row++;
 
-            layoutTable.Add(blockSearchKeyLabel, MyAlignH.Left, MyAlignV.Top, row, 0);
-            layoutTable.Add(blockSearchKeyButton, MyAlignH.Left, MyAlignV.Top, row, 1);
+            layoutTable.Add(blockSearchKeyLabel, MyAlignH.Left, MyAlignV.Center, row, 0);
+            layoutTable.Add(blockSearchKeyButton, MyAlignH.Left, MyAlignV.Center, row, 1);
             row++;
 
             layoutTable.Add(closeButton, MyAlignH.Center, MyAlignV.Center, row, 0, colSpan: 2);

--- a/ToolbarManager/Patches/MyGuiScreenGamePlayPatch.cs
+++ b/ToolbarManager/Patches/MyGuiScreenGamePlayPatch.cs
@@ -1,10 +1,13 @@
+using System;
 using System.Diagnostics.CodeAnalysis;
 using HarmonyLib;
 using Sandbox.Game.Entities.Character;
 using Sandbox.Game.Gui;
+using Sandbox.Game.Screens.Helpers;
 using Sandbox.Game.World;
 using Sandbox.Graphics.GUI;
 using ToolbarManager.Gui;
+using VRage.Game;
 using VRage.Input;
 
 namespace ToolbarManager.Patches
@@ -18,17 +21,26 @@ namespace ToolbarManager.Patches
         [HarmonyPatch(nameof(MyGuiScreenGamePlay.HandleUnhandledInput))]
         public static bool HandleUnhandledInputPrefix()
         {
-            if (MyGuiScreenGamePlay.ActiveGameplayScreen != null || !(MySession.Static.ControlledEntity is MyCharacter))
+            var myInput = MyInput.Static;
+            if (!myInput.IsNewKeyPressed(Config.Data.BlockSearchKey))
                 return true;
 
-            var myInput = MyInput.Static;
-            if (myInput.IsNewKeyPressed(Config.Data.BlockSearchKey))
+            if (MyGuiScreenGamePlay.ActiveGameplayScreen != null)
+                return true;
+
+            var toolbarType = MyToolbarComponent.CurrentToolbar?.ToolbarType;
+            switch (toolbarType)
             {
-                OpenCubeBuilder();
-                return false;
+                case MyToolbarType.Character:
+                case MyToolbarType.BuildCockpit:
+                    break;
+                default:
+                    return true;
             }
 
-            return true;
+            OpenCubeBuilder();
+            return false;
+
         }
 
         private static void OpenCubeBuilder()

--- a/ToolbarManager/Properties/AssemblyInfo.cs
+++ b/ToolbarManager/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.5.0.0")]
-[assembly: AssemblyFileVersion("1.5.0.0")]
+[assembly: AssemblyVersion("1.5.1.0")]
+[assembly: AssemblyFileVersion("1.5.1.0")]


### PR DESCRIPTION
- Using character profiles for build cockpit

This is to prevent players from thinking they lost all of their character profiles while trying to use the cockpit build mode (Ctrl-G).

This feature is enabled by default, but will not be in effect if there is any profiles aready defined for the build cockpit.

To merge your build cockpit profiles into your character profiles open the `%AppData%\SpaceEngineers\ToolbarManager` directory in `Explorer` and move all files from the `BuildCockpit` to the `Character` folder.