### PR TITLE
1.5.4

### DIFF
--- a/ToolbarManager/Gui/ProfilesDialog.cs
+++ b/ToolbarManager/Gui/ProfilesDialog.cs
@@ -142,7 +142,10 @@ namespace ToolbarManager.Gui
 
         private int CellTextComparison(MyGuiControlTable.Cell x, MyGuiControlTable.Cell y)
         {
-            return TextComparison(x.Text, y.Text);
+            if (x == null)
+                return y == null ? 0 : 1;
+            
+            return y == null ? -1 : TextComparison(x.Text, y.Text);
         }
 
         private int TextComparison(StringBuilder x, StringBuilder y)

--- a/ToolbarManager/Properties/AssemblyInfo.cs
+++ b/ToolbarManager/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.5.3.0")]
-[assembly: AssemblyFileVersion("1.5.3.0")]
+[assembly: AssemblyVersion("1.5.4.0")]
+[assembly: AssemblyFileVersion("1.5.4.0")]


### PR DESCRIPTION
Fixed #19: Added `null` checks to prevent the issue at the `CellTextComparison` level